### PR TITLE
Fix heredoc end marker for Terraform >=0.12

### DIFF
--- a/role/inputs.tf
+++ b/role/inputs.tf
@@ -127,7 +127,8 @@ variable "default-readonly-policy" {
         "kinesis:List*"
       ],
       "Resource": "*"
-    }POLICY
+    }
+  POLICY
 }
 
 variable "default-reservation-policy" {
@@ -138,7 +139,8 @@ variable "default-reservation-policy" {
         "ec2:ModifyReservedInstances"
       ],
       "Resource": "*"
-    }POLICY
+    }
+  POLICY
 }
 
 variable "default-actions-policy" {
@@ -156,5 +158,6 @@ variable "default-actions-policy" {
         "ec2:ReleaseAddress"
       ],
       "Resource": "*"
-    }POLICY
+    }
+  POLICY
 }

--- a/role/role.tf
+++ b/role/role.tf
@@ -9,7 +9,8 @@ data "template_file" "default-s3-billing-bucket-policy" {
             "s3:List*"
           ],
           "Resource": [ "arn:aws:s3:::$${s3-billing-bucket}", "arn:aws:s3:::$${s3-billing-bucket}/*" ]
-        }POLICY
+        }
+  POLICY
 
   vars {
     s3-billing-bucket = "${var.s3-billing-bucket}"
@@ -25,7 +26,8 @@ data "template_file" "default-s3-cloudtrail-bucket-policy" {
             "s3:List*"
           ],
           "Resource": [ "arn:aws:s3:::$${s3-cloudtrail-bucket}", "arn:aws:s3:::$${s3-cloudtrail-bucket}/*" ]
-        }POLICY
+        }
+  POLICY
 
   vars {
     s3-cloudtrail-bucket = "${var.s3-cloudtrail-bucket}"
@@ -41,7 +43,8 @@ data "template_file" "default-s3-cur-bucket-policy" {
             "s3:List*"
           ],
           "Resource": [ "arn:aws:s3:::$${s3-cur-bucket}", "arn:aws:s3:::$${s3-cur-bucket}/*" ]
-        }POLICY
+        }
+  POLICY
 
   vars {
     s3-cur-bucket = "${var.s3-cur-bucket}"
@@ -57,7 +60,8 @@ data "template_file" "default-s3-config-bucket-policy" {
             "s3:List*"
           ],
           "Resource": [ "arn:aws:s3:::$${s3-config-bucket}", "arn:aws:s3:::$${s3-config-bucket}/*" ]
-        }POLICY
+        }
+  POLICY
 
   vars {
     s3-config-bucket = "${var.s3-config-bucket}"
@@ -73,7 +77,8 @@ data "template_file" "default-s3-ecs-bucket-policy" {
             "s3:List*"
           ],
           "Resource": [ "arn:aws:s3:::$${s3-ecs-bucket}", "arn:aws:s3:::$${s3-ecs-bucket}/*" ]
-        }POLICY
+        }
+  POLICY
 
   vars {
     s3-ecs-bucket = "${var.s3-ecs-bucket}"
@@ -130,6 +135,6 @@ POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "cht_aws_iam_role_policy_attachment" {
-  role       = "${aws_iam_role.cht_iam_role.name}"
+  role = "${aws_iam_role.cht_iam_role.name}"
   policy_arn = "${aws_iam_policy.cht_iam_policy.arn}"
 }


### PR DESCRIPTION
Terraform >=0.12 doesn't accept the `POLICY` heredoc end marker in the same line as the curly bracket anymore.

Side note: the whitespaces in the `cht_aws_iam_role_policy_attachment` role policy attachment have been removed by `terraform format`.