### PR TITLE
Convert depreciated template_file data providers to locals

### DIFF
--- a/role/role.tf
+++ b/role/role.tf
@@ -1,88 +1,60 @@
 #Setting up internal variables
 
-data "template_file" "default-s3-billing-bucket-policy" {
-  template = <<POLICY
+locals {
+  default-s3-billing-bucket-policy = <<POLICY
 {
           "Effect": "Allow",
           "Action": [
             "s3:Get*",
             "s3:List*"
           ],
-          "Resource": [ "arn:aws:s3:::$${s3-billing-bucket}", "arn:aws:s3:::$${s3-billing-bucket}/*" ]
+          "Resource": [ "arn:aws:s3:::$${var.s3-billing-bucket}", "arn:aws:s3:::$${var.s3-billing-bucket}/*" ]
         }
   POLICY
 
-  vars = {
-    s3-billing-bucket = var.s3-billing-bucket
-  }
-}
-
-data "template_file" "default-s3-cloudtrail-bucket-policy" {
-  template = <<POLICY
+  default-s3-cloudtrail-bucket-policy = <<POLICY
 {
           "Effect": "Allow",
           "Action": [
             "s3:Get*",
             "s3:List*"
           ],
-          "Resource": [ "arn:aws:s3:::$${s3-cloudtrail-bucket}", "arn:aws:s3:::$${s3-cloudtrail-bucket}/*" ]
+          "Resource": [ "arn:aws:s3:::$${var.s3-cloudtrail-bucket}", "arn:aws:s3:::$${var.s3-cloudtrail-bucket}/*" ]
         }
   POLICY
 
-  vars = {
-    s3-cloudtrail-bucket = var.s3-cloudtrail-bucket
-  }
-}
-
-data "template_file" "default-s3-cur-bucket-policy" {
-  template = <<POLICY
+  default-s3-cur-bucket-policy = <<POLICY
 {
           "Effect": "Allow",
           "Action": [
             "s3:Get*",
             "s3:List*"
           ],
-          "Resource": [ "arn:aws:s3:::$${s3-cur-bucket}", "arn:aws:s3:::$${s3-cur-bucket}/*" ]
+          "Resource": [ "arn:aws:s3:::$${var.s3-cur-bucket}", "arn:aws:s3:::$${var.s3-cur-bucket}/*" ]
         }
   POLICY
 
-  vars = {
-    s3-cur-bucket = var.s3-cur-bucket
-  }
-}
-
-data "template_file" "default-s3-config-bucket-policy" {
-  template = <<POLICY
+  default-s3-config-bucket-policy = <<POLICY
 {
           "Effect": "Allow",
           "Action": [
             "s3:Get*",
             "s3:List*"
           ],
-          "Resource": [ "arn:aws:s3:::$${s3-config-bucket}", "arn:aws:s3:::$${s3-config-bucket}/*" ]
+          "Resource": [ "arn:aws:s3:::$${var.s3-config-bucket}", "arn:aws:s3:::$${var.s3-config-bucket}/*" ]
         }
   POLICY
 
-  vars = {
-    s3-config-bucket = var.s3-config-bucket
-  }
-}
-
-data "template_file" "default-s3-ecs-bucket-policy" {
-  template = <<POLICY
+  default-s3-ecs-bucket-policy = <<POLICY
 {
           "Effect": "Allow",
           "Action": [
             "s3:Get*",
             "s3:List*"
           ],
-          "Resource": [ "arn:aws:s3:::$${s3-ecs-bucket}", "arn:aws:s3:::$${s3-ecs-bucket}/*" ]
+          "Resource": [ "arn:aws:s3:::$${var.s3-ecs-bucket}", "arn:aws:s3:::$${var.s3-ecs-bucket}/*" ]
         }
   POLICY
-
-  vars = {
-    s3-ecs-bucket = var.s3-ecs-bucket
-  }
 }
 
 resource "aws_iam_role" "cht_iam_role" {
@@ -121,11 +93,11 @@ resource "aws_iam_policy" "cht_iam_policy" {
   "Version": "2012-10-17",
   "Statement": [
     ${var.default-readonly-policy}
-    ${var.s3-billing-bucket == "" ? "" : format(",%s", data.template_file.default-s3-billing-bucket-policy.rendered)}
-    ${var.s3-cloudtrail-bucket == "" ? "" : format(",%s", data.template_file.default-s3-cloudtrail-bucket-policy.rendered)}
-    ${var.s3-cur-bucket == "" ? "" : format(",%s", data.template_file.default-s3-cur-bucket-policy.rendered)}
-    ${var.s3-config-bucket == "" ? "" : format(",%s", data.template_file.default-s3-config-bucket-policy.rendered)}
-    ${var.s3-ecs-bucket == "" ? "" : format(",%s", data.template_file.default-s3-ecs-bucket-policy.rendered)}
+    ${var.s3-billing-bucket == "" ? "" : format(",%s", local.default-s3-billing-bucket-policy)}
+    ${var.s3-cloudtrail-bucket == "" ? "" : format(",%s", local.default-s3-cloudtrail-bucket-policy)}
+    ${var.s3-cur-bucket == "" ? "" : format(",%s", local.default-s3-cur-bucket-policy)}
+    ${var.s3-config-bucket == "" ? "" : format(",%s", local.default-s3-config-bucket-policy)}
+    ${var.s3-ecs-bucket == "" ? "" : format(",%s", local.default-s3-ecs-bucket-policy)}
     ${var.automated-ri-modification-enabled ? format(",%s", var.default-reservation-policy) : ""}
     ${var.automated-actions-enabled ? format(",%s", var.default-actions-policy) : ""}
     ${var.additional-policy == "" ? "" : format(",%s", var.additional-policy)}


### PR DESCRIPTION
Convert depreciated `template_file` data providers to [local values](https://www.terraform.io/docs/language/values/locals.html)

Since [template_file](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) was depreciated in `>= 0.12` in favor for the built-in `templatefile` [function](https://www.terraform.io/docs/language/functions/templatefile.html). However since we're just defining strings, we should probably convert these data providers to local values. 

The current version of this module requires `>= 0.12` anyway, so this should be safe to merge and release anytime. Source: https://github.com/CloudHealth/terraform-cloudhealth-iam/blob/master/README.md#requirements